### PR TITLE
Decode if the ouput is in bytes format

### DIFF
--- a/imhotep/app.py
+++ b/imhotep/app.py
@@ -19,8 +19,11 @@ log = logging.getLogger(__name__)
 
 def run(cmd, cwd='.'):
     log.debug("Running: %s", cmd)
-    return subprocess.Popen(
+    stdout = subprocess.Popen(
         [cmd], stdout=subprocess.PIPE, shell=True, cwd=cwd).communicate()[0]
+    if isinstance(stdout, bytes):
+        return stdout.decode()
+    return stdout
 
 
 def find_config(dirname, config_filenames):


### PR DESCRIPTION
## Status*
Review and merge.

## Description
When we run imhotep using python 3.6, the output of running a command is in bytes format. This is breaking the flow as we are trying to apply a string regex on the ouput. This fix ensures that we decode the output before further processing.


## Reviewers
@zoetetal 